### PR TITLE
[NDCF-28][fix] mock up a local Oracle Coordinator & Consumer

### DIFF
--- a/contracts/NFT/NotDittoAndItems.sol
+++ b/contracts/NFT/NotDittoAndItems.sol
@@ -117,6 +117,7 @@ contract NotDittoAndItems is
 
     // 不提供選擇 mint 哪一個
     // mint 只檢查條件
+    // TODO: 為了確保 NotDitto 變成 Orphan 後不會馬上被同一個 owner 領養，要變成 internal，然後到game去實作
     function mintNotDitto(address nftAddress, uint256 nftId) external payable {
         if (msg.value < MINT_PRICE) {
             revert ErrorFromInteractWithNotDitto(
@@ -190,6 +191,7 @@ contract NotDittoAndItems is
         _safeTransferFrom(from, to, NOT_DITTO, 1);
     }
 
+    // TODO: 為了確保 NotDitto 變成 Orphan 後不會馬上被同一個 owner 領養，要變成 internal，然後到game去實作
     function mintNotDittoBatch(
         uint256 amount,
         address[] memory nftAddresses,

--- a/contracts/Oracle/RandomNumber.sol
+++ b/contracts/Oracle/RandomNumber.sol
@@ -20,7 +20,10 @@ contract LotteryAndFight is VRFV2WrapperConsumerBase {
     uint32 public constant CALLBACK_GAS_LIMITATION = 1_000_000;
     uint16 public constant REQUEST_CONFIRMATIONS = 10;
     uint32 public constant NUM_WORDS = 4;
-    uint176 public lastRequestId = 1;
+
+    // TODO: 如果是要使用鏈上的 wrapper & coordinator，要自己繼續發過幾次 request 才是 index
+    // 舉例來說 Sepolia 上的目前已經到了 109633308322872451740277313816242394424923305601307255569641281954357508737320 
+    uint176 public lastRequestId = 1; 
     uint256 public lastRequestTimestamp; // 用來確保每次開獎都至少間隔一定天數
     uint256 public MIN_TIME_OF_NEXT_DRAW = 7 days; // 最少參與人數
     // requestId => RequestStatus


### PR DESCRIPTION
Chainlink has provide mockup contracts for developers to receive randomness in local net.
By following up the method of directly funding, 4 another contracts are instanced in this PR in the setup file of testing.

### testing setup
- [x] change addresses of Link token and VRFV2Wrapper for NotDittoCanFight contract
- [x] split local & Sepolia testnet (may remove setting of Sepolia since I deploy a mock LINK)
### Fixed bug
- [x] create `drawIndex` & `requestIdByDrawIndex` to fulfill functionality of engaging in different draws
- [x] remove reentry modifier for now due to no external call or thread conflict may happen